### PR TITLE
1257: Remove deprecated usage of BSON::Symbol type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,10 @@ script: "bundle exec rspec spec"
 
 language: ruby
 
+before_install: gem update bundler
+
 rvm:
-  - 2.2
-  - 2.3
-  - 2.4
-  - 2.5
-  - jruby
+  - 2.7.6
 
 services:
   - mongodb

--- a/lib/mongoid/enum.rb
+++ b/lib/mongoid/enum.rb
@@ -38,6 +38,7 @@ module Mongoid
 
       def create_field(field_name, options)
         type = options[:multiple] && Array || Symbol
+        type = type == Symbol ? Mongoid::StringifiedSymbol : type
         field field_name, :type => type, :default => options[:default]
       end
 

--- a/lib/mongoid/enum/version.rb
+++ b/lib/mongoid/enum/version.rb
@@ -1,5 +1,5 @@
 module Mongoid
   module Enum
-    VERSION = "0.4.0"
+    VERSION = "0.5.0"
   end
 end

--- a/mongoid-enum.gemspec
+++ b/mongoid-enum.gemspec
@@ -22,7 +22,8 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", "~> 3.1"
-  spec.add_development_dependency "guard-rspec", "~> 4.6.2"
-  spec.add_development_dependency "mongoid-rspec", "~> 4.0.1"
+  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "guard-rspec"
+  spec.add_development_dependency "mongoid-rspec"
+  spec.add_development_dependency "ffi", "< 1.17.0" # TODO: Remove once FFI has solved rubygem compatibility issues
 end

--- a/mongoid-enum.gemspec
+++ b/mongoid-enum.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "mongoid", ">=5", "<8"
+  spec.add_runtime_dependency "mongoid", ">=7.5", "<9"
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.1"
   spec.add_development_dependency "guard-rspec", "~> 4.6.2"

--- a/spec/mongoid/enum_spec.rb
+++ b/spec/mongoid/enum_spec.rb
@@ -59,7 +59,7 @@ describe Mongoid::Enum do
 
       context "when not multiple" do
         it "is a symbol" do
-          expect(klass).to have_field(field_name).of_type(Symbol)
+          expect(klass).to have_field(field_name).of_type(Mongoid::StringifiedSymbol)
         end
 
         it "validates inclusion in values" do


### PR DESCRIPTION
För att testa detta gem i API repot:

Byt ut raden för mongoid enum i `Gemfile` till:
```ruby
gem 'mongoid-enum', git: 'https://github.com/tv4ads/mongoid-enum', branch: 'feature/WOO-1257_remove_BSON_symbol_usage' # fork that we maintain
```

Sedan:

- Kodgranska denna PR
- Testa av API repot och se så att allting fungerar som de ska, däribland:
- - Inga varningar kastas
- - Ändring av enum fält via inbyggd `mongoid_enum` funktion fungar. Dvs, `<class>.enum_value!` fungerar (IE: `campaign.booked!`)
- - Scope via enum värde fungerar. Dvs, `<Class>.enum_value` (IE: `Campaign.booked`)

Update: Ni kan använda https://github.com/tv4ads/woo-api/pull/1686 för och testa BE med detta